### PR TITLE
Handle curl errors

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -84,58 +84,57 @@ rm -rf outputdata.json
 rm -rf dcactemp.json
 rm -rf inverterinfo.json
 
-curlError=false
+curlError=0
 echo "Please wait while curl is fetching input, grid, load, battery & output data..."
 curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial/realtime/input -o "pvindata.json"
 if [[ $? -ne 0 ]]; then
     echo "Error: Request failed for pvindata.json"
-	curlError=true
+	curlError=1
 fi
 
 curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/grid/$inverter_serial/realtime?sn=$inverter_serial -o "griddata.json"
 if [[ $? -ne 0 ]]; then
     echo "Error: Request failed for griddata.json"
-	curlError=true
+	curlError=1
 fi
 
 curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/load/$inverter_serial/realtime?sn=$inverter_serial -o "loaddata.json"
 if [[ $? -ne 0 ]]; then
     echo "Error: Request failed for loaddata.json"
-	curlError=true
+	curlError=1
 fi
 
 curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" "https://api.sunsynk.net/api/v1/inverter/battery/$inverter_serial/realtime?sn=$inverter_serial&lan=en" -o "batterydata.json"
 if [[ $? -ne 0 ]]; then
     echo "Error: Request failed for batterydata.json"
-	curlError=true
+	curlError=1
 fi
 
 curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial/realtime/output -o "outputdata.json"
 if [[ $? -ne 0 ]]; then
     echo "Error: Request failed for outputdata.json"
-	curlError=true
+	curlError=1
 fi
 
 curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" "https://api.sunsynk.net/api/v1/inverter/$inverter_serial/output/day?lan=en&date=$VarCurrentDate&column=dc_temp,igbt_temp" -o "dcactemp.json"
 if [[ $? -ne 0 ]]; then
     echo "Error: Request failed for dcactemp.json"
-	curlError=true
+	curlError=1
 fi
 
 curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial  -o "inverterinfo.json"
 if [[ $? -ne 0 ]]; then
     echo "Error: Request failed for inverterinfo.json"
-	curlError=true
+	curlError=1
 fi
 
 curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/common/setting/$inverter_serial/read  -o "settings.json"
 if [[ $? -ne 0 ]]; then
     echo "Error: Request failed for settings.json"
-	curlError=true
+	curlError=1
 fi
 
-if ! curlError
-then
+if [[ $curlError -eq 0 ]]; then
 
 inverterinfo_brand=$(jq -r '.data.brand' inverterinfo.json)
 inverterinfo_status=$(jq -r '.data.status' inverterinfo.json)

--- a/run.sh
+++ b/run.sh
@@ -84,18 +84,58 @@ rm -rf outputdata.json
 rm -rf dcactemp.json
 rm -rf inverterinfo.json
 
+curlError=false
 echo "Please wait while curl is fetching input, grid, load, battery & output data..."
-curl -s -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial/realtime/input -o "pvindata.json"
-curl -s -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/grid/$inverter_serial/realtime?sn=$inverter_serial -o "griddata.json"
-curl -s -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/load/$inverter_serial/realtime?sn=$inverter_serial -o "loaddata.json"
-curl -s -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" "https://api.sunsynk.net/api/v1/inverter/battery/$inverter_serial/realtime?sn=$inverter_serial&lan=en" -o "batterydata.json"
-curl -s -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial/realtime/output -o "outputdata.json"
-curl -s -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" "https://api.sunsynk.net/api/v1/inverter/$inverter_serial/output/day?lan=en&date=$VarCurrentDate&column=dc_temp,igbt_temp" -o "dcactemp.json"
-curl -s -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial  -o "inverterinfo.json"
-curl -s -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/common/setting/$inverter_serial/read  -o "settings.json"
+curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial/realtime/input -o "pvindata.json"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Request failed for pvindata.json"
+	curlError=true
+fi
 
+curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/grid/$inverter_serial/realtime?sn=$inverter_serial -o "griddata.json"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Request failed for griddata.json"
+	curlError=true
+fi
 
+curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/load/$inverter_serial/realtime?sn=$inverter_serial -o "loaddata.json"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Request failed for loaddata.json"
+	curlError=true
+fi
 
+curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" "https://api.sunsynk.net/api/v1/inverter/battery/$inverter_serial/realtime?sn=$inverter_serial&lan=en" -o "batterydata.json"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Request failed for batterydata.json"
+	curlError=true
+fi
+
+curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial/realtime/output -o "outputdata.json"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Request failed for outputdata.json"
+	curlError=true
+fi
+
+curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" "https://api.sunsynk.net/api/v1/inverter/$inverter_serial/output/day?lan=en&date=$VarCurrentDate&column=dc_temp,igbt_temp" -o "dcactemp.json"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Request failed for dcactemp.json"
+	curlError=true
+fi
+
+curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/inverter/$inverter_serial  -o "inverterinfo.json"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Request failed for inverterinfo.json"
+	curlError=true
+fi
+
+curl -s -f -S -k -X GET -H "Content-Type: application/json" -H "authorization: Bearer $ServerAPIBearerToken" https://api.sunsynk.net/api/v1/common/setting/$inverter_serial/read  -o "settings.json"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Request failed for settings.json"
+	curlError=true
+fi
+
+if ! curlError
+then
 
 inverterinfo_brand=$(jq -r '.data.brand' inverterinfo.json)
 inverterinfo_status=$(jq -r '.data.status' inverterinfo.json)
@@ -534,7 +574,8 @@ fi
 echo "Fetch complete for inverter: $inverter_serial"
 done
 
-
+fi
+#EOF Curl failure
 	
 fi
 #EOF Check if Token is valid

--- a/run.sh
+++ b/run.sh
@@ -568,14 +568,12 @@ else
 	curl -s -k -X POST -H "Authorization: Bearer $HA_LongLiveToken" -H "Content-Type: application/json" -d '{"attributes": {"unit_of_measurement": "", "friendly_name": "solarsynk_inverter_settings"}, "state": ""}' $HTTP_Connect_Type://$Home_Assistant_IP:$Home_Assistant_PORT/api/states/input_text.solarsynk_"$inverter_serial"_inverter_settings > /dev/null
 fi
 
-
+fi
+#EOF Curl failure
 
 # EOF Serial Number Loop
 echo "Fetch complete for inverter: $inverter_serial"
 done
-
-fi
-#EOF Curl failure
 	
 fi
 #EOF Check if Token is valid


### PR DESCRIPTION
If  getting the data from sunsynk api fails, don't update the entities as this information would be invalid as all defaulted to zeros